### PR TITLE
Support yarn 4 projects

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_ENV
+        run: echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | tail -n1)" >> $GITHUB_ENV
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | head -n1)" >> $GITHUB_ENV'
+        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | grep -E ^/ | head -n1)" >> $GITHUB_ENV'
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install apt libraries
-        run: sudo apt install gettext -y
+        run: sudo apt update && sudo apt install gettext -y
 
       - name: Setup Node.js version from .nvmrc
         uses: actions/setup-node@v4

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -30,12 +30,17 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: |
-          CACHE_DIR=$(yarn cache dir 2>&1 | sed 's/^[[:space:]]*//' | grep -E '^/' | head -n1)
+          YARN_MAJOR=$(yarn --version | cut -d. -f1)
+          if [ "$YARN_MAJOR" = "1" ]; then
+            CACHE_DIR=$(yarn cache dir)
+          else
+            CACHE_DIR=$(yarn config get cacheFolder)
+          fi
           if [ -z "$CACHE_DIR" ]; then CACHE_DIR="$RUNNER_TEMP/yarn-cache"; fi
           echo "ACTIONS_YARN_CACHE_PATH=$CACHE_DIR" >> $GITHUB_ENV
 
       - name: Cache yarn dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: yarn-cache
         with:
           path: ${{ env.ACTIONS_YARN_CACHE_PATH }}

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | tail -n1)" >> $GITHUB_ENV
+        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | tail -n1)" >> $GITHUB_ENV'
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | tail -n1)" >> $GITHUB_ENV'
+        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | head -n1)" >> $GITHUB_ENV'
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -29,7 +29,10 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: 'echo "YARN_CACHE_DIR=$(yarn cache dir 2>&1 | grep -E ^/ | head -n1)" >> $GITHUB_ENV'
+        run: |
+          CACHE_DIR=$(yarn cache dir 2>&1 | sed 's/^[[:space:]]*//' | grep -E '^/' | head -n1)
+          if [ -z "$CACHE_DIR" ]; then CACHE_DIR="$RUNNER_TEMP/yarn-cache"; fi
+          echo "YARN_CACHE_DIR=$CACHE_DIR" >> $GITHUB_ENV
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3
@@ -51,4 +54,3 @@ jobs:
 
       - name: Run typescript tests
         run: npx tsc
-        

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -32,13 +32,13 @@ jobs:
         run: |
           CACHE_DIR=$(yarn cache dir 2>&1 | sed 's/^[[:space:]]*//' | grep -E '^/' | head -n1)
           if [ -z "$CACHE_DIR" ]; then CACHE_DIR="$RUNNER_TEMP/yarn-cache"; fi
-          echo "YARN_CACHE_DIR=$CACHE_DIR" >> $GITHUB_ENV
+          echo "ACTIONS_YARN_CACHE_PATH=$CACHE_DIR" >> $GITHUB_ENV
 
       - name: Cache yarn dependencies
         uses: actions/cache@v3
         id: yarn-cache
         with:
-          path: ${{ env.YARN_CACHE_DIR }}
+          path: ${{ env.ACTIONS_YARN_CACHE_PATH }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -49,3 +51,4 @@ jobs:
 
       - name: Run typescript tests
         run: npx tsc
+        

--- a/.github/workflows/bundlemon-build-size.yml
+++ b/.github/workflows/bundlemon-build-size.yml
@@ -56,8 +56,26 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'  # Use the Node.js version specified in .nvmrc
-          cache: 'yarn'
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: |
+          CACHE_DIR=$(yarn cache dir 2>&1 | sed 's/^[[:space:]]*//' | grep -E '^/' | head -n1)
+          if [ -z "$CACHE_DIR" ]; then CACHE_DIR="$RUNNER_TEMP/yarn-cache"; fi
+          echo "ACTIONS_YARN_CACHE_PATH=$CACHE_DIR" >> $GITHUB_ENV
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ env.ACTIONS_YARN_CACHE_PATH }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Cache npm for npx-scoped tools
         uses: actions/cache@v3

--- a/.github/workflows/bundlemon-build-size.yml
+++ b/.github/workflows/bundlemon-build-size.yml
@@ -64,12 +64,17 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: |
-          CACHE_DIR=$(yarn cache dir 2>&1 | sed 's/^[[:space:]]*//' | grep -E '^/' | head -n1)
+          YARN_MAJOR=$(yarn --version | cut -d. -f1)
+          if [ "$YARN_MAJOR" = "1" ]; then
+            CACHE_DIR=$(yarn cache dir)
+          else
+            CACHE_DIR=$(yarn config get cacheFolder)
+          fi
           if [ -z "$CACHE_DIR" ]; then CACHE_DIR="$RUNNER_TEMP/yarn-cache"; fi
           echo "ACTIONS_YARN_CACHE_PATH=$CACHE_DIR" >> $GITHUB_ENV
 
       - name: Cache yarn dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: yarn-cache
         with:
           path: ${{ env.ACTIONS_YARN_CACHE_PATH }}
@@ -78,7 +83,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Cache npm for npx-scoped tools
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-npx

--- a/.github/workflows/bundlemon-build-size.yml
+++ b/.github/workflows/bundlemon-build-size.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install apt libraries
-        run: sudo apt install gettext -y
+        run: sudo apt update && sudo apt install gettext -y
 
       # Check if .bundlemonrc exists in the caller repo
       - name: Check for .bundlemonrc in caller repo


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869c9feth #869c9feth

### :memo: Implementation
Problem: In repos with "packageManager": "yarn@4.12.0" (e.g. dhis2-app-skeleton), the test job fails because the first use of yarn (e.g. in "Get yarn cache directory path") happens before Corepack is enabled, so the runner falls back to Yarn 1.x.

Changes in .github/workflows/app-test.yml:
Removed cache: "yarn" from the "Setup Node.js version from .nvmrc" step so yarn is not run before enabling Corepack.
Added an "Enable Corepack" step (corepack enable) right after setting up Node and before any yarn command.

Result: With Corepack enabled, repos without packageManager keep using Yarn 1.x; repos with packageManager use the specified version (e.g. Yarn 4). Dependency caching is unchanged and still done in "Get yarn cache directory path" and "Cache yarn dependencies".

### :video_camera: Screenshots/Screen capture

### :fire: Testing

Run the workflow on a Yarn 1 repo (no packageManager): it should still pass.
Run the workflow on a Yarn 4 repo with packageManager (e.g. dhis2-app-skeleton): the "Unit tests" job should pass; previously it failed at "Setup Node.js version from .nvmrc" / "Get yarn cache directory path" with the Corepack error.


